### PR TITLE
Increase max_http_header_data to fix proxy issues

### DIFF
--- a/rockets/serverContext.cpp
+++ b/rockets/serverContext.cpp
@@ -111,6 +111,8 @@ void ServerContext::fillContextInfo(const std::string& uri,
     info.ssl_private_key_filepath = nullptr;
     info.gid = -1;
     info.uid = -1;
+    // header size: accommodate long "Authorization: Negotiate <kerberos token>"
+    info.max_http_header_data = 8192;
     // service threads
     info.count_threads = threadCount;
     info.max_http_header_pool = threadCount;


### PR DESCRIPTION
Libwebsockets was issuing an error "Ran out of header data space" when a server was running behind an authentication proxy.

The size of the "Authorization: Negotiate <token>" header can be very long, potentially depending on the number of groups a user is a member of (https://support.microsoft.com/en-us/help/2020943).

Doubling the max_http_header_data from 4096 (default) to 8192 fixes the problem (in the BBP setup).