### PR TITLE
Work around http header pool exhaustion with lws 2.4 -> 2.4.2

### DIFF
--- a/rockets/serverContext.cpp
+++ b/rockets/serverContext.cpp
@@ -152,6 +152,9 @@ void ServerContext::fillContextInfo(const std::string& uri,
     info.max_http_header_data = 8192;
     // service threads
     info.count_threads = threadCount;
-    info.max_http_header_pool = threadCount;
+#if LWS_LIBRARY_VERSION_NUMBER <= 3000000
+    // https://github.com/warmcat/libwebsockets/issues/1249
+    info.max_http_header_pool = 1024;
+#endif
 }
 }


### PR DESCRIPTION
Increase the pool size to 1024 for lws < 3.0 as discussed here: https://github.com/warmcat/libwebsockets/issues/1249
There was no point in restricting the pool size, memory is only allocated as-needed, and should reach max 5MB. Since lws 3.0 the default ah limit == fd limit (typically 1024 as well).