### PR TITLE
Bugfix: writable callback occuring without a connection

### DIFF
--- a/rockets/server.cpp
+++ b/rockets/server.cpp
@@ -271,7 +271,10 @@ static int callback_http(lws* wsi, const lws_callback_reasons reason,
             break;
 
         case LWS_CALLBACK_HTTP_WRITEABLE:
-            return handler.writeResponse(connections.at(wsi));
+            // A writable callback may exceptionally occcur without a connection
+            if (connections.count(wsi))
+                return handler.writeResponse(connections.at(wsi));
+            break;
 
 #if LWS_LIBRARY_VERSION_NUMBER >= 2001000
         case LWS_CALLBACK_HTTP_DROP_PROTOCOL: // fall-through


### PR DESCRIPTION
This check had been removed in commit ca16bef, but it was needed.
Observed as a crash behind bbp proxy (lws 2.3).

Debugging trace:
-- wsi -- -- action --
0x1055b20 OPEN
0x1055b20 WRITE
0x1055b20 WRITE
0x1055b20 CLOSE
0x1055b20 WRITE_WITHOUT_CONNECTION

Couldn't reproduce on local workstation.