### PR TITLE
Do not find websockets as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(ROCKETS_MAINTAINER "Blue Brain Project <bbp-open-source@googlegroups.com>")
 set(ROCKETS_LICENSE LGPL)
 
 common_find_package(Boost SYSTEM COMPONENTS unit_test_framework)
-common_find_package(Libwebsockets SYSTEM)
+common_find_package(Libwebsockets)
 if(NOT Libwebsockets_FOUND) # Ubuntu package only has libwebsockets.pc
   common_find_package(libwebsockets SYSTEM REQUIRED)
   set(Libwebsockets_VERSION ${libwebsockets_VERSION})

--- a/rockets/clientContext.h
+++ b/rockets/clientContext.h
@@ -25,7 +25,7 @@
 #include <rockets/utils.h>
 #include <rockets/ws/types.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
 
 #include <string>
 #include <vector>

--- a/rockets/debug.h
+++ b/rockets/debug.h
@@ -20,7 +20,8 @@
 #ifndef ROCKETS_DEBUG_H
 #define ROCKETS_DEBUG_H
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <iostream>
 #include <string>

--- a/rockets/http/channel.h
+++ b/rockets/http/channel.h
@@ -25,7 +25,8 @@
 #include <rockets/http/response.h>
 #include <rockets/http/types.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 namespace rockets
 {

--- a/rockets/http/client.cpp
+++ b/rockets/http/client.cpp
@@ -27,7 +27,8 @@
 #include "requestHandler.h"
 #include "utils.h"
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 namespace
 {

--- a/rockets/http/connection.h
+++ b/rockets/http/connection.h
@@ -25,7 +25,8 @@
 #include <rockets/http/request.h>
 #include <rockets/http/types.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 namespace rockets
 {

--- a/rockets/http/utils.cpp
+++ b/rockets/http/utils.cpp
@@ -19,7 +19,8 @@
 
 #include "utils.h"
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 namespace rockets
 {

--- a/rockets/log.cpp
+++ b/rockets/log.cpp
@@ -20,7 +20,8 @@
 #include "proxyConnectionError.h"
 #include "unavailablePortError.h"
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <iostream>
 #include <stdexcept>

--- a/rockets/pollDescriptors.h
+++ b/rockets/pollDescriptors.h
@@ -22,7 +22,8 @@
 
 #include "types.h"
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 #include <map>
 
 namespace rockets

--- a/rockets/proxyConnectionError.h
+++ b/rockets/proxyConnectionError.h
@@ -20,7 +20,8 @@
 #ifndef ROCKETS_PROXYCONNECTIONERROR_H
 #define ROCKETS_PROXYCONNECTIONERROR_H
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <stdexcept>
 

--- a/rockets/server.cpp
+++ b/rockets/server.cpp
@@ -32,7 +32,8 @@
 #include "ws/connection.h"
 #include "ws/messageHandler.h"
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <mutex>
 #include <set>

--- a/rockets/serverContext.h
+++ b/rockets/serverContext.h
@@ -25,7 +25,8 @@
 #include <rockets/utils.h>
 #include <rockets/ws/types.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <string>
 #include <vector>

--- a/rockets/utils.h
+++ b/rockets/utils.h
@@ -20,7 +20,8 @@
 #ifndef ROCKETS_UTILS_H
 #define ROCKETS_UTILS_H
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <memory>
 #include <string>

--- a/rockets/websockets.h
+++ b/rockets/websockets.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// This header-file includes <libwebsockets.h> but disables it warnings.
+//
+// When using GCC6 and later we cannot include it using -isystem since that
+// messes with the system include order causing compilation errors.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <libwebsockets.h>
+#pragma GCC diagnostic pop
+#endif

--- a/rockets/ws/channel.h
+++ b/rockets/ws/channel.h
@@ -22,7 +22,8 @@
 
 #include <rockets/ws/types.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 namespace rockets
 {

--- a/tests/http.cpp
+++ b/tests/http.cpp
@@ -31,7 +31,8 @@
 #include <rockets/http/response.h>
 #include <rockets/server.h>
 
-#include <libwebsockets.h>
+#include <rockets/websockets.h>
+
 
 #include <iostream>
 #include <map>


### PR DESCRIPTION
For some reason I needed to remove this when I compiled on Arch Linux. I tried this on my Ubuntu machine and it seems to work fine.