### PR TITLE
fix(cpp): unit test for unavailable ports on OSX 10.14

### DIFF
--- a/tests/http.cpp
+++ b/tests/http.cpp
@@ -249,7 +249,14 @@ BOOST_AUTO_TEST_CASE(listening_on_os_chosen_port)
 
 BOOST_AUTO_TEST_CASE(listening_on_unavailable_port_throws)
 {
-    BOOST_CHECK_THROW(Server(":80", ""), std::runtime_error);
+#ifndef __APPLE__
+    const auto port = ":80";
+#else
+    // ports < 1024 are no longer restricted since OSX 10.14 (Mojave)
+    Server server1;
+    const auto port = std::string(":") + std::to_string(server1.getPort());
+#endif
+    BOOST_CHECK_THROW(Server(port, ""), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(listening_on_localhost)

--- a/tests/websockets.cpp
+++ b/tests/websockets.cpp
@@ -80,7 +80,14 @@ BOOST_AUTO_TEST_CASE(server_construction)
 
 BOOST_AUTO_TEST_CASE(listening_on_unavailable_port_throws)
 {
-    BOOST_CHECK_THROW(Server(":80", wsProtocol), std::runtime_error);
+#ifndef __APPLE__
+    const auto port = ":80";
+#else
+    // ports < 1024 are no longer restricted since OSX 10.14 (Mojave)
+    Server server1;
+    const auto port = std::string(":") + std::to_string(server1.getPort());
+#endif
+    BOOST_CHECK_THROW(Server(port, wsProtocol), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(client_connection_to_inexistant_server)


### PR DESCRIPTION
Since OSX Mojave the ports below 1024 are no longer restricted to root.
https://news.ycombinator.com/item?id=18302380